### PR TITLE
Chore: upgrade rubocop v0.64.0

### DIFF
--- a/rubocop/Dockerfile
+++ b/rubocop/Dockerfile
@@ -1,9 +1,15 @@
 FROM ruby:2.3-alpine
 LABEL maintainer="Josh Mostafa <jmostafa@cozero.com.au>"
 
-ENV RUBOCOP_VERSION=0.52.1
+ENV RUBOCOP_VERSION=0.64.0
 
-RUN apk add --update bash \
+RUN apk update \
+  && apk add --virtual build-dependencies \
+      build-base \
+      gcc \
+      wget \
+      git \
+  && apk add bash \
   && rm -rf /var/cache/apk/* \
   && gem install rubocop -v ${RUBOCOP_VERSION}
 

--- a/rubocop/test-config.yaml
+++ b/rubocop/test-config.yaml
@@ -4,7 +4,7 @@ commandTests:
   - name: "rubocop version"
     command: "rubocop"
     args: ["-v"]
-    expectedOutput: ["0.52.1"]
+    expectedOutput: ["0.64.0"]
 
 fileExistenceTests:
   - name: 'linter script'


### PR DESCRIPTION
Note: still using ruby:2.3-alpine. Perhaps consider upgrading to ruby:2.6-alpine.